### PR TITLE
Add ".foss" to package name and APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,10 +20,11 @@ android {
             zipAlignEnabled true
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            applicationIdSuffix ".foss"
 
             android.applicationVariants.all { variant ->
                 variant.outputs.all {
-                    outputFileName = "GeometricWeather ${variant.versionName}.apk"
+                    outputFileName = "GeometricWeather ${variant.versionName}-foss.apk"
                 }
             }
         }


### PR DESCRIPTION
This should completely separate the FOSS version from the mainline app.

Resolves #1.